### PR TITLE
feat: add meta as an addon's resource and define a meta handler

### DIFF
--- a/addon.js
+++ b/addon.js
@@ -19,6 +19,7 @@ const manifest = {
 	],
 	"resources": [
 		"catalog",
+		"meta",
 		"stream"
 	],
 	"types": [
@@ -78,6 +79,31 @@ builder.defineCatalogHandler(({type, id, extra}) => {
 			return { metas: [] };
 		});
 })
+
+builder.defineMetaHandler(({type, id}) => {
+	console.log(`requesting meta: ${type} ${id}`)
+	// Docs: https://github.com/Stremio/stremio-addon-sdk/blob/master/docs/api/requests/defineMetaHandler.md
+
+	if (type === "movie") {
+		return getMovieDetails(id)
+			.then(movieDetails => {
+				const meta = {
+					id: movieDetails.slug,
+					type: "movie",
+					name: movieDetails.title,
+					poster: movieDetails.featured,
+					background: movieDetails.background_image,
+					description: movieDetails.overview,
+					imdbRating: movieDetails.imdb,
+					releaseInfo: movieDetails.year
+				}
+
+				return { meta };
+			})
+	}
+
+	return Promise.resolve({ meta: { } })
+});
 
 builder.defineStreamHandler(({type, id}) => {
 	console.log("request for streams: "+type+" "+id)


### PR DESCRIPTION
### Context
- To provide information about movies, we need to set meta as a resource provided from this addon

### Changelog
- Add meta and define a handler to return information about the movie

### QA

![image](https://github.com/user-attachments/assets/67165799-fb68-4364-8dcb-c72cf09b0325)
